### PR TITLE
Allow setting the language in spatial-hub

### DIFF
--- a/grails-app/conf/application.yml
+++ b/grails-app/conf/application.yml
@@ -22,8 +22,6 @@ grails:
         upload:
             maxFileSize: 10000000
             maxRequestSize: 10000000
-i18n:
-  region: 'default'
 
 layersService:
     url: 'https://spatial.ala.org.au/ws'

--- a/grails-app/controllers/au/org/ala/spatial/portal/PortalController.groovy
+++ b/grails-app/controllers/au/org/ala/spatial/portal/PortalController.groovy
@@ -99,6 +99,8 @@ class PortalController {
                         spApp.put(k, v.class.newInstance(params.get(k, v)))
                     }
 
+                    config.i18n?.currentRegion = org.springframework.context.i18n.LocaleContextHolder.getLocale()?.getLanguage()
+
                     render(view: 'index',
                             model: [config     : config,
                                     userId     : userId,

--- a/grails-app/controllers/au/org/ala/spatial/portal/PortalController.groovy
+++ b/grails-app/controllers/au/org/ala/spatial/portal/PortalController.groovy
@@ -98,12 +98,8 @@ class PortalController {
                     config.spApp.each { k, v ->
                         spApp.put(k, v.class.newInstance(params.get(k, v)))
                     }
-                    if (params.get("lang")) {
-                        config.i18n?.currentRegion = params.get("lang")
-                    } else {
-                        config.i18n?.currentRegion = null;
-                    }
 
+                    config.i18n?.currentRegion = org.springframework.context.i18n.LocaleContextHolder.getLocale()?.getISO3Language()
 
                     render(view: 'index',
                             model: [config     : config,

--- a/grails-app/controllers/au/org/ala/spatial/portal/PortalController.groovy
+++ b/grails-app/controllers/au/org/ala/spatial/portal/PortalController.groovy
@@ -99,8 +99,6 @@ class PortalController {
                         spApp.put(k, v.class.newInstance(params.get(k, v)))
                     }
 
-                    config.i18n?.currentRegion = org.springframework.context.i18n.LocaleContextHolder.getLocale()?.getISO3Language()
-
                     render(view: 'index',
                             model: [config     : config,
                                     userId     : userId,

--- a/grails-app/views/portal/index.gsp
+++ b/grails-app/views/portal/index.gsp
@@ -1,4 +1,5 @@
 <%@ page import="grails.converters.JSON" %>
+<g:set var="lang" value="${session.'org.springframework.web.servlet.i18n.SessionLocaleResolver.LOCALE'}"/>
 <!doctype html>
 <html lang="en">
 
@@ -74,9 +75,7 @@
         baseLayers: ${(config.startup.baselayers as grails.converters.JSON).toString().encodeAsRaw()},
         defaultBaseLayer: '${config.startup.baselayer.default}',
 
-        <g:if test="${config.i18n?.region}">
-        i18n: '${config.i18n?.region}',
-        </g:if>
+        i18n: '${lang}',
 
         <g:if test="${config.flickr.url}">
         flickrUrl: '${config.flickr.url}',

--- a/grails-app/views/portal/index.gsp
+++ b/grails-app/views/portal/index.gsp
@@ -1,5 +1,4 @@
 <%@ page import="grails.converters.JSON" %>
-<g:set var="lang" value="${session.'org.springframework.web.servlet.i18n.SessionLocaleResolver.LOCALE'}"/>
 <!doctype html>
 <html lang="en">
 
@@ -75,7 +74,7 @@
         baseLayers: ${(config.startup.baselayers as grails.converters.JSON).toString().encodeAsRaw()},
         defaultBaseLayer: '${config.startup.baselayer.default}',
 
-        i18n: '${lang}',
+        i18n: '${config.i18n?.currentRegion}',
 
         <g:if test="${config.flickr.url}">
         flickrUrl: '${config.flickr.url}',

--- a/grails-app/views/portal/index.gsp
+++ b/grails-app/views/portal/index.gsp
@@ -74,8 +74,8 @@
         baseLayers: ${(config.startup.baselayers as grails.converters.JSON).toString().encodeAsRaw()},
         defaultBaseLayer: '${config.startup.baselayer.default}',
 
-        <g:if test="${config.i18n?.currentRegion}">
-        i18n: '${config.i18n?.currentRegion}',
+        <g:if test="${config.i18n?.region}">
+        i18n: '${config.i18n?.region}',
         </g:if>
 
         <g:if test="${config.flickr.url}">


### PR DESCRIPTION
Use the same grails mechanism as the other services for picking the language.
This allows us to maintain the same language across services using a single cookie.

We do this by adding an xml in our docker builds:
```
<?xml version="1.0" encoding="UTF-8"?>
<beans xmlns="http://www.springframework.org/schema/beans"
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
    xsi:schemaLocation="http://www.springframework.org/schema/beans
        http://www.springframework.org/schema/beans/spring-beans.xsd">
    <bean id="localeResolver" class="org.springframework.web.servlet.i18n.CookieLocaleResolver">
        <property name="defaultLocale" value="nl"/>
        <property name="cookieName" value="vbp-lang"/>
        <property name="cookieMaxAge" value="31536000"/>
        <property name="cookieHttpOnly" value="false" />
        <property name="cookieSecure" value="true" />
    </bean>
</beans>
```

But without that xml, this change should not change any behavior :pray: 
As the default grails also using the lang url parameter to set the language.
(It will only save the selected language for the duration of the session)