### PR TITLE
fix: filter request headers during proxying and propagate status code

### DIFF
--- a/grails-app/controllers/au/org/ala/spatial/portal/PortalController.groovy
+++ b/grails-app/controllers/au/org/ala/spatial/portal/PortalController.groovy
@@ -559,14 +559,18 @@ class PortalController {
             if (request.method == HttpGet.METHOD_NAME) {
                 def value = grailsCacheManager.getCache(portalService.caches.PROXY).get(target)
                 if (value) {
-                    response.setContentType((String) ((Map) value.get()).contentType)
-                    ((Map) value.get()).headers.each { k, v ->
+                    def mapValue = (Map) value.get()
+                    if (mapValue.statusCode) {
+                        response.setStatus((int) mapValue.statusCode)
+                    }
+                    response.setContentType((String) mapValue.contentType)
+                    mapValue.headers.each { k, v ->
                         response.setHeader(k, v)
                     }
-                    if (((Map) value.get()).contentType.startsWith("image")) {
-                        response.outputStream << ((Map) value.get()).text
+                    if (mapValue.contentType.startsWith("image")) {
+                        response.outputStream << mapValue.text
                     } else {
-                        response.outputStream << new String(((Map) value.get()).text)
+                        response.outputStream << new String(mapValue.text)
                     }
                 } else {
                     def headers = [:]
@@ -575,6 +579,9 @@ class PortalController {
                     value = hubWebService.getUrlMap(target, headers)
                     if (value) {
                         grailsCacheManager.getCache(portalService.caches.PROXY).put(target, value)
+                        if (value.statusCode) {
+                            response.setStatus((int) value.statusCode)
+                        }
                         response.setContentType(String.valueOf(value.contentType))
                         if (value.contentType.startsWith("image")) {
                             response.outputStream << value.text

--- a/grails-app/services/au/org/ala/spatial/portal/HubWebService.groovy
+++ b/grails-app/services/au/org/ala/spatial/portal/HubWebService.groovy
@@ -245,14 +245,13 @@ class HubWebService {
             }
 
             if (headers) {
+                def ignoredHeaders = [
+                    'host', 'authorization', 'cookie', 'cookie2',
+                    'connection', 'keep-alive', 'proxy-authenticate', 'proxy-authorization',
+                    'te', 'trailers', 'transfer-encoding', 'upgrade'
+                ] as Set
                 headers.each { k, v ->
-                    /*
-                    //Why excludes default headers, like Accept
-                    if (k != null && !excludedHeaders.contains(k.toString().toLowerCase()) && !HttpHeaders.COOKIE.equalsIgnoreCase(k.toString())) {
-                        call.addRequestHeader(String.valueOf(k), String.valueOf(v))
-                    }
-                    */
-                    if (k != null && !HttpHeaders.COOKIE.equalsIgnoreCase(k.toString())) {
+                    if (k != null && !ignoredHeaders.contains(k.toString().toLowerCase())) {
                         call.setRequestHeader(String.valueOf(k), String.valueOf(v))
                     }
                 }


### PR DESCRIPTION
Filters out Host, Authorization, Cookie, and other hop-by-hop headers from proxied GET requests to prevent target servers/gateways from rejecting them. Also propagates status codes back to the client.