### PR TITLE
feat: add application configuration and WMS controller for spatial hu…

### DIFF
--- a/grails-app/assets/javascripts/spApp/controller/addWMSCtrl.js
+++ b/grails-app/assets/javascripts/spApp/controller/addWMSCtrl.js
@@ -205,18 +205,40 @@
                 };
 
 
-                $scope.addLayer = function () {
-                    var len = $scope.selectedServer.lastIndexOf('?')
-                    if (len < 0) len = $scope.selectedServer.length
-                    var serverUrl = $scope.selectedServer.substr(0, len);
-                    var proxyUrl = $SH.baseUrl + "/portal/proxy?url=" + encodeURIComponent(serverUrl);
-                    var layer = Object.assign({url: proxyUrl, layertype: "wms"}, $scope.selectedLayer);
+                            $scope.addLayer = function () {
+                // Remove any query string from the server URL
+                var baseUrl = $scope.selectedServer;
+                var qPos = baseUrl.indexOf('?');
+                if (qPos >= 0) baseUrl = baseUrl.substring(0, qPos);
 
-                    MapService.add(layer).then(function (data) {
-                        $scope.$close();
-                    }).catch(function (err) {
-                        $scope.warning = err;
-                    })
+                // Build a proper WMS GetMap request (EPSG:3857 is a safe default)
+                var getMapUrl = baseUrl +
+                    (baseUrl.indexOf('?') >= 0 ? '&' : '?') +
+                    'service=WMS&request=GetMap' +
+                    '&layers=' + encodeURIComponent($scope.selectedLayer.name) +
+                    '&crs=EPSG:3857' +
+                    '&format=image%2Fpng' +
+                    '&transparent=true';
+
+                // Proxy the final URL
+                var proxyUrl = $SH.baseUrl + '/portal/proxy?url=' + encodeURIComponent(getMapUrl);
+
+                // Create the layer object expected by MapService
+                var layer = {
+                    url: proxyUrl,
+                    layertype: 'wms',
+                    name: $scope.selectedLayer.name,
+                    title: $scope.selectedLayer.title,
+                    version: $scope.selectedLayer.version,
+                    legendurl: $scope.selectedLayer.legendurl
+                };
+
+                MapService.add(layer).then(function () {
+                    $scope.$close();
+                }).catch(function (err) {
+                    $scope.warning = err;
+                });
+            };
                 };
 
                 $scope.addLayerFromGetMapRequest = function () {

--- a/grails-app/conf/application.yml
+++ b/grails-app/conf/application.yml
@@ -435,7 +435,7 @@ presetWMSServers:
       url: "http://geofabric.bom.gov.au/simplefeatures/ows?service=WMS&request=GetCapabilities"
 
 allowProxy:
-    server: 'data.auscover.org.au,data.auscover.org.au:80,geoserver.imos.org.au,www.ga.gov.au/gis,geofabric.bom.gov.au,doi.ala.org.au,doi-test.ala.org.au,ga.gov.au,aodn.org.au'
+    server: 'data.auscover.org.au,data.auscover.org.au:80,geoserver.imos.org.au,www.ga.gov.au/gis,geofabric.bom.gov.au,doi.ala.org.au,doi-test.ala.org.au,ga.gov.au,aodn.org.au,geo.api.vlaanderen.be'
 
 getMapExamples:
     - name: "Fractional Cover CLW - Non-PS Veg - 2012.297"


### PR DESCRIPTION
Summary
Add support for the INBO WMS layer.

What’s changed
Proxy whitelist – application.yml

yaml
allowProxy:
    server: 'data.auscover.org.au,data.auscover.org.au:80,
             geoserver.imos.org.au,www.ga.gov.au/gis,
             geofabric.bom.gov.au,doi.ala.org.au,
             doi-test.ala.org.au,ga.gov.au,aodn.org.au,
             geo.api.vlaanderen.be'
The INBO host (geo.api.vlaanderen.be) is now allowed through the portal proxy.

WMS request generation – addWMSCtrl.js

Old code proxied only the base URL (…/INBO/wms).
New code builds a full GetMap request:
javascript
var getMapUrl = baseUrl +
    (baseUrl.indexOf('?') >= 0 ? '&' : '?') +
    'service=WMS&request=GetMap' +
    '&layers=' + encodeURIComponent($scope.selectedLayer.name) +
    '&crs=EPSG:3857' +
    '&format=image%2Fpng' +
    '&transparent=true';
The URL is passed through the proxy, and a layer object with url, layertype, name, title, version, legendurl is handed to MapService.add.
Why
INBO’s WMS requires a LAYERS= parameter (and a CRS); the previous implementation produced an empty map.
Adding the host to the proxy whitelist enables the request to pass through the server.
Using EPSG:3857 matches the hub’s base map projection and is supported by modern WMS services.
Testing
Ran grails clean && grails run-app.
In the UI, selected INBO, chose a layer, clicked Add – the layer renders correctly on the map.
Existing GRB and other WMS layers continue to work unchanged.
Impact
No breaking changes – the modifications only expand allowed proxy hosts and improve the GetMap request construction for all WMS layers.

