### PR TITLE
fix: pass exact style name from GetCapabilities to WMS tile requests

### DIFF
--- a/grails-app/assets/javascripts/spApp/controller/addWMSCtrl.js
+++ b/grails-app/assets/javascripts/spApp/controller/addWMSCtrl.js
@@ -133,9 +133,7 @@
                                 var nameKey = Object.keys(firstStyle).find(function (k) { return k.toLowerCase() === 'name'; });
                                 if (!nameKey) return '';
                                 var nameVal = firstStyle[nameKey];
-                                var styleName = textOf(nameVal);
-                                // Treat 'default' as empty — equivalent to omitting STYLES in WMS spec
-                                return styleName.toLowerCase() === 'default' ? '' : styleName;
+                                return textOf(nameVal);
                             }
 
                             function getLegendUrl(lyr) {


### PR DESCRIPTION
ArcGIS WMS servers (gisservices.inbo.be) require the style name to be passed explicitly (e.g. STYLES=default) as declared in GetCapabilities. Sending STYLES='' (empty) causes the server to not render the layer.

Remove the 'default' -> '' normalisation so the style name is passed exactly as the server declared it in <Style><Name>.