### PR TITLE
feat: add WMS button to map panel homepage

### DIFF
--- a/grails-app/assets/javascripts/spApp/directive/spMap.js
+++ b/grails-app/assets/javascripts/spApp/directive/spMap.js
@@ -39,6 +39,10 @@
                         return scope.addLayer(layerId);
                     }
 
+                    scope.openAddWMS = function() {
+                        LayoutService.openModal('addWMS');
+                    }
+
                     scope.addLayer = function (layerId) {
                         var promises = [];
                         var item = LayersService.convertFieldIdToMapLayer(layerId, true)

--- a/grails-app/assets/javascripts/spApp/templates/mapContent.tpl.htm
+++ b/grails-app/assets/javascripts/spApp/templates/mapContent.tpl.htm
@@ -110,6 +110,22 @@
           </a>
         </td>
         <td style="padding: 4px">
+          <a href="#" ng-click="openAddWMS()" alt="WMS-lagen toevoegen" title="WMS-lagen toevoegen">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
+              <!-- Background -->
+              <rect x="2" y="2" width="60" height="60" rx="6" ry="6" fill="#a83d7a" stroke="#7a1f52" stroke-width="2"/>
+              <!-- Globe -->
+              <circle cx="32" cy="27" r="15" fill="none" stroke="white" stroke-width="2"/>
+              <line x1="17" y1="27" x2="47" y2="27" stroke="white" stroke-width="1.5"/>
+              <ellipse cx="32" cy="19.5" rx="9" ry="3.5" fill="none" stroke="white" stroke-width="1.5"/>
+              <ellipse cx="32" cy="34.5" rx="9" ry="3.5" fill="none" stroke="white" stroke-width="1.5"/>
+              <ellipse cx="32" cy="27" rx="7" ry="15" fill="none" stroke="white" stroke-width="1.5"/>
+              <!-- WMS label -->
+              <text x="32" y="55" text-anchor="middle" font-family="Arial, sans-serif" font-size="12" font-weight="bold" fill="white" letter-spacing="1">WMS</text>
+            </svg>
+          </a>
+        </td>
+        <td style="padding: 4px">
           <a href="#" ng-click="addVhga()" alt="Add Vlaamse Hydrografische Atlas layer to the map" title="Add Vlaamse Hydrografische Atlas layer to the map">
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
               <!-- Blue background -->


### PR DESCRIPTION
Add a prominent fuchsia globe+WMS icon button in the INBO quick-access row alongside BWK/Landbouw/VHGA. Clicking it opens the Add WMS Layer modal (addWMS) via LayoutService.openModal.